### PR TITLE
Remove Ruby <= 1.8 support

### DIFF
--- a/lib/pathological/base.rb
+++ b/lib/pathological/base.rb
@@ -245,13 +245,8 @@ module Pathological
     # .../gems/pathological-0.2.2.1/lib/pathological.rb
     pathological_file_pattern = %r{/pathological(/[^/]+|)\.rb}
     requiring_file = Kernel.caller.find do |stack_line|
-      if RUBY_VERSION.start_with?("1.9")
-        # In Ruby 1.9, top-level files will have the string "top (required)" included in the stack listing.
-        stack_line.include?("top (required)") && stack_line !~ pathological_file_pattern
-      else
-        # In Ruby 1.8, top-level files are listed with their relative path and without a line number.
-        stack_line !~ /:\d+:in/ && stack_line !~ pathological_file_pattern
-      end
+      # In Ruby >= 1.9, top-level files will have the string "top (required)" included in the stack listing.
+      stack_line.include?("top (required)") && stack_line !~ pathological_file_pattern
     end
     requiring_file ? requiring_file.match(/(.+):\d+/)[1] : $0 rescue $0
   end

--- a/test/unit/pathological/base_test.rb
+++ b/test/unit/pathological/base_test.rb
@@ -114,15 +114,6 @@ module Pathological
             /Users/test/repos/pathological/test/rackup/app.rb:1:in `<top (required)>'
             /Users/test/.rubies/1.9.2-p290/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
           EOS
-          @full_18_stacktrace = <<-EOS.dedent.split("\n").reject(&:empty?)
-            /Users/test/ruby/gems/1.8/gems/pathological-0.2.5/lib/pathological/base.rb:61:in `find_pathfile'
-            /Users/test/ruby/gems/1.8/gems/pathological-0.2.5/lib/pathological/base.rb:36:in `find_load_paths'
-            /Users/test/ruby/gems/1.8/gems/pathological-0.2.5/lib/pathological/base.rb:15:in `add_paths!'
-            /Users/test/ruby/gems/1.8/gems/pathological-0.2.5/lib/pathological.rb:3
-            /Users/test/ruby/site_ruby/1.8/rubygems/custom_require.rb:58:in `gem_original_require'
-            /Users/test/ruby/site_ruby/1.8/rubygems/custom_require.rb:58:in `require'
-            app.rb:2
-          EOS
           @bad_stacktrace = <<-EOS.dedent.split("\n").reject(&:empty?)
             /Users/test/repos/pathological/test/rackup/app.rb !!! `<top (required)>'
           EOS
@@ -130,11 +121,7 @@ module Pathological
         end
 
         should "find root file from a stacktrace" do
-          if RUBY_VERSION.start_with?("1.9")
-            stub(Kernel).caller { @full_19_stacktrace }
-          else
-            stub(Kernel).caller { @full_18_stacktrace }
-          end
+          stub(Kernel).caller { @full_19_stacktrace }
           assert_equal "app.rb", File.basename(Pathological.requiring_filename)
         end
 


### PR DESCRIPTION
Because of the dependence on ruby version string comparison,
Pathological currently breaks on ruby >= 2.0, as it uses the ruby 1.8
fallback logic.

An alternative to removing 1.8 support outright would be to do proper
version comparison, using something like Gem::Version [1]. 'Gem' isn't
provided by default on ruby 1.8, however.

Ruby 1.8.7 was officially sunsetted ~2 years ago [2], so I think removing
support outright is fine. It also cleans the code up slightly.

[1] - http://stackoverflow.com/a/3064161/1273175
[2] - https://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/

---

Please note that I couldn't get tests to even run, as it appears some of the test dependencies are out of date. Pertinent Gemfile.lock info:

```
dedent (1.0.1)
fakefs (0.6.7)
minitest (5.6.0)
rake (10.4.2)
rr (1.1.2)
scope (0.2.3)
```
